### PR TITLE
chore(log): Log why a PHP version was skipped/used

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -165,9 +165,11 @@ function copy(obj) {
             version = parseFloat(version.toFixed(1));
             if (await isPhpVersionReleased(version)) {
                 php.push(version.toFixed(1));
+                console.log(`Release for PHP Version ${version.toFixed(1)} exists`);
             } else {
                 // no more minors for this major
                 version = Math.ceil(version) - 0.1;
+                console.log(`No release for PHP Version ${version.toFixed(1)} exists -> skipping`);
             }
         }
         php.sort();
@@ -178,6 +180,10 @@ function copy(obj) {
             if (await distroSupportsPhpVersion(version)) {
                 distroPhp.push(version)
                 availablePhp = version;
+
+                console.log(`Install candidates for PHP Version ${version.toFixed(1)} found`);
+            } else {
+                console.log(`No install candidates for PHP version ${version.toFixed(1)} found -> skipping`);
             }
         }
 


### PR DESCRIPTION
Be a bit more verbose about why we (not) choose a PHP version.
