### PR TITLE
chore: Update used GitHub Actions and introduce version pinning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: A job to test the action
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Execute action
       id: run


### PR DESCRIPTION
This PR introduces version pinning (like universally used now by other GitHub Actions within the Nextcloud universe) and updates the checkout action to the latest version.